### PR TITLE
cmo-250 Add PatternReplaceCharFilterFactory to remove special non mapped characters in Turkish analyzer

### DIFF
--- a/cmo-webapp/src/main/solrHome/cmo/conf/schema.xml
+++ b/cmo-webapp/src/main/solrHome/cmo/conf/schema.xml
@@ -400,6 +400,7 @@
       <filter class="solr.TurkishLowerCaseFilterFactory"/>
       <filter class="solr.StopFilterFactory" words="lang/stopwords_tr.txt" ignoreCase="false"/>
       <filter class="solr.ASCIIFoldingFilterFactory"/>
+      <filter class="solr.PatternReplaceCharFilterFactory" pattern="[^\w\s]" replacement=""/>
       <filter class="solr.SnowballPorterFilterFactory" language="Turkish"/>
     </analyzer>
   </fieldType>


### PR DESCRIPTION

After special characters which have a mapping like û are mapped to ascii u, we remove all other non ascii chars like ʿ

fixes #250 