### PR TITLE
[#288] - Add +/- and up/down buttons for notation type

### DIFF
--- a/cmo-module/src/main/resources/META-INF/resources/editor/editor-includes.xed
+++ b/cmo-module/src/main/resources/META-INF/resources/editor/editor-includes.xed
@@ -346,8 +346,8 @@
   </xed:template>
 
   <xed:template id="cmo_notationType">
-    <cmo:selectClassification xpath="mei:classification/classEntry[@authority='cmo_notationType']"
-                              label="editor.search.notationType"
+    <cmo:selectClassification xpath="mei:classification/classEntry[@authority='cmo_notationType']" repeat="true" min="1"
+                              max="10" label="editor.search.notationType"
                               classification="cmo_notationType" help-text="{i18n:cmo.help.notationType}" />
   </xed:template>
 


### PR DESCRIPTION
Closes #288

Makes the "notation type" field in the source editor repeatable, so a source can carry more than one notation type. Previously only a single entry was possible.

## Changes
- **Editor**: made the `cmo_notationType` field repeatable (`repeat="true" min="1" max="10"`), mirroring the existing `cmo_contentType` field. This reuses the standard repeat controls (insert / remove / up / down), so multiple `mei:term` elements can be added, deleted and reordered within the `cmo_notationType` `mei:termList`. Applies to both source editors (`manuscript.xed` and `print.xed`).

## Why nothing else needs changing
The rest of the pipeline already handles multiple terms:
- **MEI mapping** (`xeditor2mei.xsl`): groups multiple `classEntry[@authority='cmo_notationType']` into one `mei:termList` with multiple `mei:term`.
- **Solr schema**: `expression.source.notationType` is already `multiValued="true"`.
- **Solr indexing** (`solr/mei.xsl`): iterates over each `mei:term`.
- **Detail view** (`mei/classification.xsl`): iterates over all `mei:term`.

## Test
- `mvn -pl cmo-module install` passes.