### PR TITLE
Add derivate_types classification and menu action to set the derivate type

### DIFF
--- a/cmo-cli/src/main/config/classifications/derivate_types.xml
+++ b/cmo-cli/src/main/config/classifications/derivate_types.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mycoreclass xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="MCRClassification.xsd" ID="derivate_types">
+  <label xml:lang="de" text="Dateibereichtyp" />
+  <label xml:lang="en" text="Type of file area" />
+  <label xml:lang="tr" text="Dosya alanı türü" />
+  <categories>
+    <category ID="content">
+      <label xml:lang="de" text="Inhalt" />
+      <label xml:lang="en" text="Content" />
+      <label xml:lang="tr" text="İçerik" />
+    </category>
+    <category ID="edition_tei">
+      <label xml:lang="de" text="Editions TEI" />
+      <label xml:lang="en" text="Edition TEI" />
+      <label xml:lang="tr" text="Edisyon TEI" />
+    </category>
+  </categories>
+</mycoreclass>

--- a/cmo-cli/src/main/config/classifications/derivate_types.xml
+++ b/cmo-cli/src/main/config/classifications/derivate_types.xml
@@ -10,9 +10,9 @@
       <label xml:lang="tr" text="İçerik" />
     </category>
     <category ID="edition_tei">
-      <label xml:lang="de" text="Editions TEI" />
-      <label xml:lang="en" text="Edition TEI" />
-      <label xml:lang="tr" text="Edisyon TEI" />
+      <label xml:lang="de" text="Textedition" />
+      <label xml:lang="en" text="Text Edition" />
+      <label xml:lang="tr" text="Metin Baskısı" />
     </category>
   </categories>
 </mycoreclass>

--- a/cmo-cli/src/main/config/setup-commands.txt
+++ b/cmo-cli/src/main/config/setup-commands.txt
@@ -1,4 +1,5 @@
 update all classifications from directory ${app.home}/config/classifications
+update classification from file ${app.home}/config/classifications/derivate_types.xml
 update classification from url https://mycore.de/classifications/diniPublType.xml
 update classification from url https://mycore.de/classifications/state.xml
 update classification from url https://mycore.de/classifications/mcr-roles.xml

--- a/cmo-module/src/main/java/de/vzg/cmo/resources/CMODerivateResource.java
+++ b/cmo-module/src/main/java/de/vzg/cmo/resources/CMODerivateResource.java
@@ -1,0 +1,122 @@
+/*
+ * This file is part of ***  M y C o R e  ***
+ * See http://www.mycore.de/ for details.
+ *
+ * MyCoRe is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MyCoRe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MyCoRe.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.vzg.cmo.resources;
+
+import java.net.URI;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.mycore.access.MCRAccessException;
+import org.mycore.access.MCRAccessManager;
+import org.mycore.datamodel.classifications2.MCRCategoryDAOFactory;
+import org.mycore.datamodel.classifications2.MCRCategoryID;
+import org.mycore.datamodel.metadata.MCRDerivate;
+import org.mycore.datamodel.metadata.MCRMetaClassification;
+import org.mycore.datamodel.metadata.MCRMetadataManager;
+import org.mycore.datamodel.metadata.MCRObjectDerivate;
+import org.mycore.datamodel.metadata.MCRObjectID;
+import org.mycore.frontend.MCRFrontendUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Resource which allows to set the {@code derivate_types} classification of a derivate.
+ * <p>
+ * The type is used to distinguish the different file areas of a derivate (e.g. the actual
+ * content or a TEI edition). The single supported classification is {@code derivate_types}.
+ */
+@Path("cmo/derivate/")
+public class CMODerivateResource {
+
+    /**
+     * The classification which holds the possible derivate types.
+     */
+    public static final String DERIVATE_TYPES_CLASSIFICATION = "derivate_types";
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    /**
+     * Sets the {@code derivate_types} category of the given derivate to the given type and
+     * redirects back to the page the request came from (or to the owning object page).
+     *
+     * @param derivateID the id of the derivate to change
+     * @param type       the category id inside the {@link #DERIVATE_TYPES_CLASSIFICATION} classification
+     * @param request    the current request, used to determine the redirect target
+     * @return a redirect response back to the referring page
+     */
+    @Path("{derid}/set-type/{type}")
+    @GET
+    public Response setType(@PathParam("derid") String derivateID, @PathParam("type") String type,
+        @Context HttpServletRequest request) {
+        if (!MCRObjectID.isValid(derivateID)) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid derivate id " + derivateID).build();
+        }
+
+        MCRObjectID derId = MCRObjectID.getInstance(derivateID);
+        if (!MCRMetadataManager.exists(derId)) {
+            return Response.status(Response.Status.NOT_FOUND).entity("Derivate " + derivateID + " does not exist")
+                .build();
+        }
+
+        if (!MCRAccessManager.checkPermission(derId, MCRAccessManager.PERMISSION_WRITE)) {
+            return Response.status(Response.Status.FORBIDDEN)
+                .entity("No permission to write derivate " + derivateID).build();
+        }
+
+        MCRCategoryID categoryID = new MCRCategoryID(DERIVATE_TYPES_CLASSIFICATION, type);
+        if (!MCRCategoryDAOFactory.getInstance().exist(categoryID)) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity("Unknown derivate type " + type).build();
+        }
+
+        MCRDerivate derivate = MCRMetadataManager.retrieveMCRDerivate(derId);
+        MCRObjectDerivate objectDerivate = derivate.getDerivate();
+
+        // replace any previously set derivate type
+        objectDerivate.getClassifications()
+            .removeIf(classification -> DERIVATE_TYPES_CLASSIFICATION.equals(classification.getClassId()));
+        objectDerivate.getClassifications()
+            .add(new MCRMetaClassification("classification", 0, null, categoryID));
+
+        try {
+            MCRMetadataManager.update(derivate);
+        } catch (MCRAccessException e) {
+            return Response.status(Response.Status.FORBIDDEN)
+                .entity("No permission to write derivate " + derivateID).build();
+        }
+
+        LOGGER.info("Set derivate type of {} to {}", derivateID, type);
+        return Response.seeOther(getRedirectTarget(request, derivate.getOwnerID())).build();
+    }
+
+    private URI getRedirectTarget(HttpServletRequest request, MCRObjectID ownerID) {
+        String referer = request.getHeader("Referer");
+        if (referer != null && !referer.isBlank()) {
+            return URI.create(referer);
+        }
+        return URI.create(MCRFrontendUtil.getBaseURL() + "receive/" + ownerID);
+    }
+
+}

--- a/cmo-module/src/main/resources/xsl/objectActions.xsl
+++ b/cmo-module/src/main/resources/xsl/objectActions.xsl
@@ -422,6 +422,32 @@
               </a>
             </li>
           </xsl:if>
+          <xsl:if test="key('rights', $deriv)/@write">
+            <li class="dropdown-header">
+              <xsl:variable name="typeClassLabels"
+                select="document('classification:metadata:0:children:derivate_types')/mycoreclass/label" />
+              <xsl:choose>
+                <xsl:when test="$typeClassLabels[@xml:lang=$CurrentLang]">
+                  <xsl:value-of select="$typeClassLabels[@xml:lang=$CurrentLang]/@text" />
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:value-of select="$typeClassLabels[@xml:lang='en']/@text" />
+                </xsl:otherwise>
+              </xsl:choose>
+            </li>
+            <xsl:variable name="currentType"
+              select="$derivate/mycorederivate/derivate/classifications/classification[@classid='derivate_types']/@categid" />
+            <xsl:call-template name="derivateTypeMenuItem">
+              <xsl:with-param name="deriv" select="$deriv" />
+              <xsl:with-param name="typeId" select="'content'" />
+              <xsl:with-param name="currentType" select="$currentType" />
+            </xsl:call-template>
+            <xsl:call-template name="derivateTypeMenuItem">
+              <xsl:with-param name="deriv" select="$deriv" />
+              <xsl:with-param name="typeId" select="'edition_tei'" />
+              <xsl:with-param name="currentType" select="$currentType" />
+            </xsl:call-template>
+          </xsl:if>
           <xsl:if test="key('rights', $deriv)/@read">
             <li class="dropdown-item">
               <a href="{$ServletsBaseURL}MCRZipServlet/{$deriv}" class="option dropdown-link">
@@ -439,6 +465,39 @@
         </ul>
       </div>
     </div>
+  </xsl:template>
+
+  <!-- Renders one entry of the derivate type selector. Marks the currently set type with a check icon. -->
+  <xsl:template name="derivateTypeMenuItem">
+    <xsl:param name="deriv" />
+    <xsl:param name="typeId" />
+    <xsl:param name="currentType" />
+    <li class="dropdown-item">
+      <a href="{$WebApplicationBaseURL}rsc/cmo/derivate/{$deriv}/set-type/{$typeId}" class="option dropdown-link">
+        <xsl:choose>
+          <xsl:when test="$currentType = $typeId">
+            <span class="fas fa-check"></span>
+          </xsl:when>
+          <xsl:otherwise>
+            <span class="fas fa-fw"></span>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:text> </xsl:text>
+        <xsl:variable name="typeCategory"
+          select="document(concat('classification:metadata:0:children:derivate_types:', $typeId))//category[@ID=$typeId]" />
+        <xsl:choose>
+          <xsl:when test="$typeCategory/label[@xml:lang=$CurrentLang]">
+            <xsl:value-of select="$typeCategory/label[@xml:lang=$CurrentLang]/@text" />
+          </xsl:when>
+          <xsl:when test="$typeCategory/label[@xml:lang='en']">
+            <xsl:value-of select="$typeCategory/label[@xml:lang='en']/@text" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$typeId" />
+          </xsl:otherwise>
+        </xsl:choose>
+      </a>
+    </li>
   </xsl:template>
 
 


### PR DESCRIPTION
## Summary

Adds the `derivate_types` classification to the project and lets editors set a derivate's type directly from the derivate actions menu.

## Changes

- **Classification**: local `derivate_types` classification with two categories, `content` (Inhalt) and `edition_tei` (Editions TEI). Loaded during setup via `update classification from file`.
- **Resource**: `CMODerivateResource` at `rsc/cmo/derivate/{id}/set-type/{type}`. Validates the id, checks write permission, validates the category against the classification, replaces any existing `derivate_types` entry and redirects back.
- **Menu**: a "type of file area" section in the derivate actions dropdown. The currently set type is marked with a check icon; clicking an entry sets it.
- **i18n**: keys added for de, en and tr.

## Notes

- The `derivate_types` classification only contains `content` and `edition_tei` on purpose, not the full upstream list.
- Existing German `messages_de.properties` stays ISO-8859-1; only ASCII keys were appended.

## Test

- `mvn -pl cmo-module -am clean install` builds green.
- Menu shows both types, marks the active one, and setting a type persists and redirects back.