### PR TITLE
[#294] - Embed TEI edition and XML source in viewer tabs

### DIFF
--- a/cmo-module/src/main/resources/META-INF/resources/scss/bootstrap-cmo.scss
+++ b/cmo-module/src/main/resources/META-INF/resources/scss/bootstrap-cmo.scss
@@ -15,5 +15,6 @@
 @import "cmo/search";
 @import "cmo/responsive";
 @import "cmo/buttons";
+@import "cmo/tei";
 
 @import "cmo/bootstrapFixes";

--- a/cmo-module/src/main/resources/META-INF/resources/scss/cmo/_metadata.scss
+++ b/cmo-module/src/main/resources/META-INF/resources/scss/cmo/_metadata.scss
@@ -85,3 +85,44 @@ span.standardized {
 [data-upload-target].well {
   text-align: center;
 }
+
+/* Upload boxes: visually separate "upload into an existing file container" from
+   "create a new file container" so it is clear what an upload will do. */
+.cmo-file-upload-box {
+  border-style: dashed;
+  border-width: 2px;
+
+  .cmo-file-upload-box__title {
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+  }
+
+  .cmo-file-upload-box__hint {
+    font-size: 0.9em;
+    color: $gray;
+  }
+}
+
+/* Upload into the already existing file container shown above: muted and pulled
+   up so it reads as belonging to that container. */
+.cmo-file-upload-box--existing {
+  border-color: $gray-lighter;
+  background-color: $cmo_purple_footerBack;
+  margin-top: -20px;
+  margin-bottom: 30px;
+
+  .cmo-file-upload-box__title {
+    color: $gray;
+  }
+}
+
+/* Create a brand new file container: accent coloured so it clearly is a
+   different action from uploading into an existing container. */
+.cmo-file-upload-box--new {
+  border-color: $info;
+  margin-bottom: 30px;
+
+  .cmo-file-upload-box__title {
+    color: $info;
+  }
+}

--- a/cmo-module/src/main/resources/META-INF/resources/scss/cmo/_tei.scss
+++ b/cmo-module/src/main/resources/META-INF/resources/scss/cmo/_tei.scss
@@ -1,0 +1,221 @@
+/* ---------------------------------------------------------------------------
+   viewer tabs (image / pdf viewer and TEI text edition)
+----------------------------------------------------------------------------*/
+#cmo-viewer {
+  margin-bottom: 30px;
+
+  .cmo-viewer-tabs {
+    border-bottom-color: $cmo_shadow;
+  }
+
+  .cmo-viewer-tab-content {
+    border: 1px solid $cmo_shadow;
+    border-top: 0;
+    padding: 24px;
+  }
+
+  .viewer {
+    margin-bottom: 0 !important;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+   TEI text edition rendering (see xsl/TEI-cmoedition.xsl)
+----------------------------------------------------------------------------*/
+.cmo-tei-loading {
+  padding: 48px 0;
+  text-align: center;
+  color: $gray;
+}
+
+.cmo-tei-edition {
+  color: $body-color;
+  line-height: $line-height-base;
+
+  .cmo-tei-title {
+    margin: 0 0 1.25rem;
+    font-size: 1.6rem;
+    color: $headings-color;
+  }
+
+  .cmo-tei-section-heading {
+    margin: 2rem 0 1rem;
+    padding-bottom: .3rem;
+    border-bottom: 2px solid $info;
+    color: $headings-color;
+    font-size: 1.05rem;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+  }
+
+  /* metadata as label / value rows */
+  .cmo-tei-meta {
+    display: grid;
+    grid-template-columns: 12rem 1fr;
+    gap: .35rem 1.5rem;
+    margin: 0;
+
+    dt {
+      color: $gray;
+      font-weight: 600;
+    }
+
+    dd {
+      margin: 0;
+    }
+  }
+
+  /* verse groups and single lines */
+  .cmo-tei-lg {
+    margin: 1.25rem 0;
+    padding-left: 1rem;
+    border-left: 2px solid $gray-lighter;
+  }
+
+  .cmo-tei-rhyme {
+    display: inline-block;
+    margin-bottom: .4rem;
+    color: $gray-light;
+    font-size: .75rem;
+    letter-spacing: .15em;
+    text-transform: uppercase;
+  }
+
+  .cmo-tei-line {
+    display: flex;
+    margin: 0;
+    line-height: 1.8;
+  }
+
+  .cmo-tei-line-no {
+    flex: 0 0 2rem;
+    padding-right: .75rem;
+    color: $gray-lighter;
+    font-size: .75rem;
+    text-align: right;
+    user-select: none;
+  }
+
+  .cmo-tei-line-text {
+    flex: 1 1 auto;
+  }
+
+  /* terennüm / vocables sit back from the sung main text */
+  .cmo-tei-seg-terennum {
+    color: $gray;
+    font-style: italic;
+  }
+
+  /* performance directions (mükerrer, miyānḫāne, ...) */
+  .cmo-tei-stage {
+    display: inline-block;
+    margin: 0 .25rem;
+    padding: 0 .4rem;
+    border-radius: 3px;
+    background-color: #eeeef3;
+    color: $info;
+    font-size: .8rem;
+    font-style: normal;
+    vertical-align: middle;
+  }
+
+  /* editorial additions */
+  .cmo-tei-supplied {
+    border-bottom: 1px dotted $gray-light;
+  }
+
+  /* critical apparatus */
+  .cmo-tei-apparatus {
+    font-size: .9rem;
+
+    .cmo-tei-lemma {
+      font-weight: 600;
+      color: $body-color;
+    }
+
+    .cmo-tei-readings {
+      margin: 0;
+
+      dt {
+        margin-top: .5rem;
+      }
+
+      dd {
+        margin: 0 0 0 1rem;
+        color: $gray;
+      }
+    }
+  }
+
+  .cmo-tei-piece-note {
+    margin-top: 1.5rem;
+    color: $gray;
+    font-size: .9rem;
+  }
+}
+
+@media (max-width: 576px) {
+  .cmo-tei-edition .cmo-tei-meta {
+    grid-template-columns: 1fr;
+    gap: 0;
+
+    dt {
+      margin-top: .5rem;
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------------
+   raw XML source view (see xsl/TEI-cmosource.xsl)
+----------------------------------------------------------------------------*/
+.cmo-xml-source {
+  pre.cmo-xml {
+    margin: 0;
+    padding: 1rem 1.25rem;
+    max-height: 75vh;
+    overflow: auto;
+    background-color: $cmo_purple_footerBack;
+    border: 1px solid $cmo_shadow;
+    border-radius: 4px;
+    font-size: .82rem;
+    line-height: 1.6;
+    tab-size: 2;
+
+    code {
+      white-space: pre;
+      color: $body-color;
+      background: none;
+      padding: 0;
+    }
+  }
+
+  /* syntax colours, kept on theme */
+  .cmo-xml-tag {
+    color: $info;
+  }
+
+  .cmo-xml-attr-name {
+    color: $success;
+  }
+
+  .cmo-xml-attr-value {
+    color: $danger;
+  }
+
+  .cmo-xml-punct {
+    color: $gray-light;
+  }
+
+  .cmo-xml-text {
+    color: $body-color;
+  }
+
+  .cmo-xml-comment {
+    color: $gray;
+    font-style: italic;
+  }
+
+  .cmo-xml-pi {
+    color: $gray;
+  }
+}

--- a/cmo-module/src/main/resources/config/cmo/messages_de.properties
+++ b/cmo-module/src/main/resources/config/cmo/messages_de.properties
@@ -198,6 +198,8 @@ cmo.sourceType                     = Source Type
 cmo.subselect.description          = Klicken Sie auf einen Titel um seine Referenz zu \u00FCbernehmen.
 cmo.upload.addDerivate             = Hinzuf\u00FCgen eines Dateibereiches
 cmo.upload.drop.derivate           = Dateien/Verzeichnisse zum Anh\u00E4ngen ablegen oder <a class="mcr-upload-show">durchsuchen</a>.
+cmo.upload.drop.title.existing     = Zu diesem Dateibereich hinzuf\u00FCgen
+cmo.upload.drop.title.new          = Neuen Dateibereich anlegen
 cmo.usul                           = Usul
 cmo.validation.failed              = Bitte korrigieren Sie die folgenden Eingabefehler in den markierten Feldern:
 cmo.validation.identifier          = Bitte geben Sie einen projektspezifischen Identifikator an.
@@ -388,3 +390,7 @@ language.en        = English
 language.noText    = Language:
 
 metaData.previewInProcessing = Die Vorschau f\u00FCr {0} ist in Bearbeitung. Bitte versuchen Sie es sp\u00E4ter noch einmal.
+
+cmo.viewer.preview                 = Vorschau
+cmo.viewer.tei.loading             = Textedition wird geladen ...
+cmo.viewer.xml.loading             = XML wird geladen ...

--- a/cmo-module/src/main/resources/config/cmo/messages_en.properties
+++ b/cmo-module/src/main/resources/config/cmo/messages_en.properties
@@ -176,6 +176,8 @@ cmo.sourceType                     = Source Type
 cmo.subselect.description          = Click a titel to add the document as a reference.
 cmo.upload.addDerivate             = Add another filespace
 cmo.upload.drop.derivate           = Drop files or directories to attach or <a class="mcr-upload-show">browse</a>.
+cmo.upload.drop.title.existing     = Add to this filespace
+cmo.upload.drop.title.new          = Create a new filespace
 cmo.usul                           = Usul
 cmo.validation.failed              = Please fix the following validation errors in the marked fields: 
 cmo.validation.identifier          = Please enter a CMO identifier.
@@ -353,3 +355,7 @@ editor.validate.oneExpression        = Please specify at least one expression!
 editor.validate.title                = Please specify title!
 
 metaData.previewInProcessing = The Preview for {0} is processing. Please try again later.
+
+cmo.viewer.preview                 = Preview
+cmo.viewer.tei.loading             = Loading text edition ...
+cmo.viewer.xml.loading             = Loading XML ...

--- a/cmo-module/src/main/resources/config/cmo/messages_tr.properties
+++ b/cmo-module/src/main/resources/config/cmo/messages_tr.properties
@@ -61,3 +61,7 @@ editor.legend.pubDate                = Yay\u0131m tarihi
 editor.search.sort                   = S\u0131ralama
 editor.search.sort.relevance         = Konuyla ilgili s\u0131ralama
 editor.search.sort.title             = Ba\u015Fl\u0131\u011Fa g\u00F6re s\u0131rala
+
+cmo.viewer.preview                 = \u00D6nizleme
+cmo.viewer.tei.loading             = Metin bask\u0131s\u0131 y\u00FCkleniyor ...
+cmo.viewer.xml.loading             = XML y\u00FCkleniyor ...

--- a/cmo-module/src/main/resources/config/cmo/mycore.properties
+++ b/cmo-module/src/main/resources/config/cmo/mycore.properties
@@ -164,6 +164,20 @@ MCR.URIResolver.xslIncludes.xeditor=editor/xeditor-custom.xsl
 MCR.ContentTransformer.datacite.Class=org.mycore.common.content.transformer.MCRXSLTransformer
 MCR.ContentTransformer.datacite.Stylesheet=xsl/mycoreobject-datacite-cmo.xsl
 
+# Renders a TEI text edition (edition_tei derivate) to an HTML fragment for the
+# edition tab. Selected by the MCRDerivateContentTransformerServlet via docType "TEI"
+# and XSL.Style=cmoedition. Uses Saxon because the stylesheet is XSLT 3.0.
+MCR.ContentTransformer.TEI-cmoedition.Class=org.mycore.common.content.transformer.MCRXSLTransformer
+MCR.ContentTransformer.TEI-cmoedition.Stylesheet=xsl/TEI-cmoedition.xsl
+MCR.ContentTransformer.TEI-cmoedition.TransformerFactoryClass=net.sf.saxon.TransformerFactoryImpl
+
+# Renders the raw XML of a derivate main file to a pretty printed, syntax highlighted
+# HTML fragment for the "(XML)" tab. Selected by the MCRDerivateContentTransformerServlet
+# via docType "TEI" and XSL.Style=cmosource. Uses Saxon because the stylesheet is XSLT 3.0.
+MCR.ContentTransformer.TEI-cmosource.Class=org.mycore.common.content.transformer.MCRXSLTransformer
+MCR.ContentTransformer.TEI-cmosource.Stylesheet=xsl/TEI-cmosource.xsl
+MCR.ContentTransformer.TEI-cmosource.TransformerFactoryClass=net.sf.saxon.TransformerFactoryImpl
+
 MCR.URIResolver.ModuleResolver.meiclassification=de.vzg.cmo.CMOClassificationURIResolver
 MCR.URIResolver.ModuleResolver.cmo_relation=de.vzg.cmo.CMORelationResolver
 MCR.URIResolver.ModuleResolver.cmo_gnd_lobid=de.vzg.cmo.CMOGNDLobidResolver

--- a/cmo-module/src/main/resources/xsl/TEI-cmoedition.xsl
+++ b/cmo-module/src/main/resources/xsl/TEI-cmoedition.xsl
@@ -1,0 +1,278 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Renders a CMO TEI text edition (edition_tei derivate) into a self-contained HTML
+  fragment. The fragment is loaded lazily into the edition tab of the object page via
+  the MCRDerivateContentTransformerServlet (see layout/viewer.xsl).
+
+  This stylesheet is XSLT 3.0 and is executed with Saxon (see the TEI-cmoedition
+  content transformer in mycore.properties). Because the output method is "html" the
+  layout template is not applied and a bare fragment is produced.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cmo="http://www.corpus-musicae-ottomanicae.de/ns/tei"
+                xpath-default-namespace="http://www.tei-c.org/ns/1.0"
+                exclude-result-prefixes="xs cmo"
+                version="3.0">
+
+  <xsl:output method="html" indent="no" omit-xml-declaration="yes" />
+
+  <!-- current interface language, provided by MyCoRe; falls back to German -->
+  <xsl:param name="CurrentLang" select="'de'" />
+
+  <!-- selects the label matching the current language (de / en / tr) -->
+  <xsl:function name="cmo:l" as="xs:string">
+    <xsl:param name="de" as="xs:string" />
+    <xsl:param name="en" as="xs:string" />
+    <xsl:param name="tr" as="xs:string" />
+    <xsl:sequence select="if ($CurrentLang = 'en') then $en
+                          else if ($CurrentLang = 'tr') then $tr
+                          else $de" />
+  </xsl:function>
+
+  <xsl:variable name="header" select="/TEI/teiHeader" />
+  <xsl:variable name="titleStmt" select="$header/fileDesc/titleStmt" />
+
+  <xsl:template match="/TEI">
+    <div class="cmo-tei-edition">
+      <xsl:call-template name="editionHeader" />
+      <xsl:apply-templates select="text/body/div[@type = 'newPieceStart']" />
+      <xsl:apply-templates select="text/body/div[@type = 'blockLyricsTranscription']" />
+      <xsl:apply-templates select="text/body//note[@type = 'lyricist']" mode="pieceNote" />
+      <xsl:call-template name="apparatus" />
+    </div>
+  </xsl:template>
+
+  <!-- ============================ header ============================ -->
+
+  <xsl:template name="editionHeader">
+    <!-- plain divs on purpose: the page has global CSS for <header> and <section> -->
+    <div class="cmo-tei-header">
+      <h2 class="cmo-tei-title" lang="ota">
+        <xsl:value-of select="$titleStmt/title/title[@type = 'titleTranscription']" />
+      </h2>
+      <dl class="cmo-tei-meta">
+        <xsl:call-template name="metaRow">
+          <xsl:with-param name="label" select="cmo:l('Makam', 'Makam', 'Makam')" />
+          <xsl:with-param name="value" select="$titleStmt/title/note[@type = 'makamTranscription']" />
+        </xsl:call-template>
+        <xsl:call-template name="metaRow">
+          <xsl:with-param name="label" select="cmo:l('Usul', 'Usul', 'Usul')" />
+          <xsl:with-param name="value" select="$titleStmt/title/note[@type = 'usulTranscription']" />
+        </xsl:call-template>
+        <xsl:call-template name="metaRow">
+          <xsl:with-param name="label" select="cmo:l('Gattung', 'Genre', 'Tür')" />
+          <xsl:with-param name="value"
+                          select="string-join($titleStmt/title/note[@type = 'genreTranscription']
+                                              ! normalize-space(.), ', ')" />
+        </xsl:call-template>
+        <xsl:call-template name="metaRow">
+          <xsl:with-param name="label" select="cmo:l('Bahir', 'Bahir', 'Bahir')" />
+          <xsl:with-param name="value" select="$titleStmt/title/note[@type = 'bahir']" />
+        </xsl:call-template>
+        <xsl:call-template name="metaRow">
+          <xsl:with-param name="label" select="cmo:l('Metrum', 'Meter', 'Vezin')" />
+          <xsl:with-param name="value" select="$titleStmt/title/note[@type = 'meter']" />
+        </xsl:call-template>
+        <xsl:call-template name="metaRow">
+          <xsl:with-param name="label" select="cmo:l('Signatur', 'Shelfmark', 'Yer numarası')" />
+          <xsl:with-param name="value" select="$titleStmt/title/idno" />
+        </xsl:call-template>
+        <xsl:call-template name="metaRow">
+          <xsl:with-param name="label" select="cmo:l('Textdichter', 'Lyricist', 'Söz yazarı')" />
+          <xsl:with-param name="value" select="$titleStmt/author[@role = 'lyricist']/persName" />
+        </xsl:call-template>
+        <xsl:if test="$titleStmt/editor">
+          <dt>
+            <xsl:value-of select="cmo:l('Bearbeitung', 'Editors', 'Editörler')" />
+          </dt>
+          <dd>
+            <xsl:value-of select="string-join($titleStmt/editor, ' · ')" />
+          </dd>
+        </xsl:if>
+      </dl>
+    </div>
+  </xsl:template>
+
+  <!-- renders one term/definition pair, but only if a value is present -->
+  <xsl:template name="metaRow">
+    <xsl:param name="label" as="xs:string" />
+    <xsl:param name="value" />
+    <xsl:if test="normalize-space(string($value)) != ''">
+      <dt>
+        <xsl:value-of select="$label" />
+      </dt>
+      <dd lang="ota">
+        <xsl:value-of select="normalize-space(string($value))" />
+      </dd>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- ======================= manuscript info ======================= -->
+
+  <xsl:template match="div[@type = 'newPieceStart']">
+    <xsl:variable name="item" select="msDesc/msContents/msItem" />
+    <div class="cmo-tei-source">
+      <h3 class="cmo-tei-section-heading">
+        <xsl:value-of select="cmo:l('Quelle', 'Source', 'Kaynak')" />
+      </h3>
+      <dl class="cmo-tei-meta">
+        <xsl:call-template name="metaRow">
+          <xsl:with-param name="label" select="cmo:l('Handschrift', 'Manuscript', 'El yazması')" />
+          <xsl:with-param name="value" select="msDesc/msIdentifier/idno" />
+        </xsl:call-template>
+        <xsl:call-template name="metaRow">
+          <xsl:with-param name="label" select="cmo:l('Stücknummer', 'Piece number', 'Parça no')" />
+          <xsl:with-param name="value" select="$item/rubric[@type = 'pieceNumber']" />
+        </xsl:call-template>
+        <xsl:call-template name="metaRow">
+          <xsl:with-param name="label" select="cmo:l('Blatt / Seite', 'Folio / page', 'Varak / sayfa')" />
+          <xsl:with-param name="value" select="$item/locus" />
+        </xsl:call-template>
+        <xsl:call-template name="metaRow">
+          <xsl:with-param name="label" select="cmo:l('Incipit', 'Incipit', 'İncipit')" />
+          <xsl:with-param name="value" select="$item/incipit" />
+        </xsl:call-template>
+      </dl>
+    </div>
+  </xsl:template>
+
+  <!-- ========================== lyrics ============================= -->
+
+  <xsl:template match="div[@type = 'blockLyricsTranscription']">
+    <div class="cmo-tei-lyrics">
+      <xsl:attribute name="dir">
+        <xsl:choose>
+          <xsl:when test="contains(@rend, 'direction:rtl')">rtl</xsl:when>
+          <xsl:otherwise>ltr</xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
+      <xsl:if test="head">
+        <h3 class="cmo-tei-lyrics-head" lang="ota">
+          <xsl:apply-templates select="head/node()" />
+        </h3>
+      </xsl:if>
+      <xsl:apply-templates select="lg" />
+    </div>
+  </xsl:template>
+
+  <xsl:template match="lg">
+    <div class="cmo-tei-lg">
+      <xsl:if test="@rhyme">
+        <span class="cmo-tei-rhyme" title="{cmo:l('Reimschema', 'Rhyme scheme', 'Kafiye düzeni')}">
+          <xsl:value-of select="@rhyme" />
+        </span>
+      </xsl:if>
+      <xsl:apply-templates select="l" />
+    </div>
+  </xsl:template>
+
+  <xsl:template match="l">
+    <p class="cmo-tei-line" lang="ota">
+      <span class="cmo-tei-line-no">
+        <xsl:value-of select="@n" />
+      </span>
+      <span class="cmo-tei-line-text">
+        <xsl:apply-templates select="node()" />
+      </span>
+    </p>
+  </xsl:template>
+
+  <xsl:template match="seg">
+    <!-- map the (possibly non ASCII) @ana value to a safe css class suffix -->
+    <xsl:variable name="kind" as="xs:string">
+      <xsl:choose>
+        <xsl:when test="@ana = 'mainPartLyrics'">main</xsl:when>
+        <xsl:when test="@ana = 'terennüm'">terennum</xsl:when>
+        <xsl:when test="@ana = 'instruction'">instruction</xsl:when>
+        <xsl:otherwise>other</xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <span class="cmo-tei-seg cmo-tei-seg-{$kind}">
+      <xsl:apply-templates select="node()" />
+    </span>
+  </xsl:template>
+
+  <!-- stage directions (mükerrer, miyānḫāne, ...) are shown as small inline badges -->
+  <xsl:template match="stage">
+    <span class="cmo-tei-stage cmo-tei-stage-{(@type, 'other')[1]}">
+      <xsl:apply-templates select="node()" />
+    </span>
+  </xsl:template>
+
+  <!-- ======================== apparatus ============================ -->
+
+  <xsl:template name="apparatus">
+    <xsl:variable name="readings" select="/TEI/text/back/div[@type = 'readings']/app" />
+    <xsl:variable name="provenance" select="/TEI/text/back/div[@type = 'provenance']/app" />
+    <xsl:if test="$provenance">
+      <div class="cmo-tei-apparatus">
+        <h3 class="cmo-tei-section-heading">
+          <xsl:value-of select="cmo:l('Überlieferung', 'Transmission', 'Aktarım')" />
+        </h3>
+        <xsl:for-each select="$provenance">
+          <p class="cmo-tei-app-note">
+            <span class="cmo-tei-lemma" lang="ota">
+              <xsl:value-of select="lem" />
+            </span>
+            <xsl:apply-templates select="note/node()" />
+          </p>
+        </xsl:for-each>
+      </div>
+    </xsl:if>
+    <xsl:if test="$readings">
+      <div class="cmo-tei-apparatus">
+        <h3 class="cmo-tei-section-heading">
+          <xsl:value-of select="cmo:l('Lesarten', 'Variant readings', 'Nüsha farkları')" />
+        </h3>
+        <dl class="cmo-tei-readings">
+          <xsl:for-each select="$readings">
+            <dt class="cmo-tei-lemma" lang="ota">
+              <xsl:value-of select="lem" />
+            </dt>
+            <xsl:for-each select="rdg">
+              <dd class="cmo-tei-rdg" lang="ota">
+                <xsl:apply-templates select="node()" />
+              </dd>
+            </xsl:for-each>
+          </xsl:for-each>
+        </dl>
+      </div>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- final per-piece notes (e.g. lyricist attribution) -->
+  <xsl:template match="note[@type = 'lyricist']" mode="pieceNote">
+    <p class="cmo-tei-piece-note" lang="ota">
+      <xsl:apply-templates select="node()" />
+    </p>
+  </xsl:template>
+
+  <!-- ==================== inline element handling =================== -->
+
+  <!-- editorial addition -->
+  <xsl:template match="supplied">
+    <span class="cmo-tei-supplied" title="{cmo:l('Ergänzung des Herausgebers', 'Editorial addition', 'Editör eklemesi')}">
+      <xsl:apply-templates select="node()" />
+    </span>
+  </xsl:template>
+
+  <!-- references: keep the text, they are cross document anchors -->
+  <xsl:template match="ref">
+    <span class="cmo-tei-ref">
+      <xsl:apply-templates select="node()" />
+    </span>
+  </xsl:template>
+
+  <!-- witness sigla on a variant reading -->
+  <xsl:template match="rdg/@wit">
+    <!-- handled implicitly, see rdg text; no output here -->
+  </xsl:template>
+
+  <!-- anchors only mark word boundaries for the apparatus, drop them -->
+  <xsl:template match="anchor" />
+
+  <!-- swallow milestones inside the rendered blocks -->
+  <xsl:template match="milestone" />
+
+</xsl:stylesheet>

--- a/cmo-module/src/main/resources/xsl/TEI-cmosource.xsl
+++ b/cmo-module/src/main/resources/xsl/TEI-cmosource.xsl
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Renders the raw XML of a derivate main file (e.g. a CMO TEI edition) into a
+  self-contained, pretty printed and syntax highlighted HTML fragment. The fragment
+  is loaded lazily into the "(XML)" tab of the object page via the
+  MCRDerivateContentTransformerServlet (see layout/viewer.xsl).
+
+  The stylesheet walks the source tree and emits <span> elements carrying css classes
+  for tags, attributes, values, text and comments. The colouring itself lives in
+  scss/cmo/_tei.scss. No external JavaScript highlighter is needed.
+
+  This stylesheet is XSLT 3.0 and is executed with Saxon (see the TEI-cmosource
+  content transformer in mycore.properties). Because the output method is "html" the
+  layout template is not applied and a bare fragment is produced.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cmo="http://www.corpus-musicae-ottomanicae.de/ns/tei"
+                exclude-result-prefixes="xs cmo"
+                version="3.0">
+
+  <xsl:output method="html" indent="no" omit-xml-declaration="yes" />
+
+  <!-- one indentation step is two spaces, repeated per nesting depth -->
+  <xsl:function name="cmo:indent" as="xs:string">
+    <xsl:param name="depth" as="xs:integer" />
+    <xsl:sequence select="string-join((1 to $depth) ! '  ', '')" />
+  </xsl:function>
+
+  <xsl:template match="/">
+    <div class="cmo-xml-source">
+      <pre class="cmo-xml"><code><xsl:apply-templates
+          select="node()[not(self::text())]" mode="xml" /></code></pre>
+    </div>
+  </xsl:template>
+
+  <!-- ============================ elements ============================ -->
+
+  <xsl:template match="*" mode="xml">
+    <xsl:param name="depth" as="xs:integer" select="0" />
+    <xsl:param name="inline" as="xs:boolean" select="false()" />
+
+    <!-- mixed content: an element that also holds significant text is kept on one
+         line so the original (possibly meaningful) whitespace is preserved -->
+    <xsl:variable name="mixed" as="xs:boolean" select="exists(text()[normalize-space()])" />
+    <xsl:variable name="hasContent" as="xs:boolean"
+                  select="exists(node()[not(self::text()[not(normalize-space())])])" />
+    <xsl:variable name="block" as="xs:boolean"
+                  select="not($inline) and exists(*) and not($mixed)" />
+
+    <xsl:if test="not($inline)">
+      <xsl:value-of select="cmo:indent($depth)" />
+    </xsl:if>
+    <span class="cmo-xml-punct">&lt;</span>
+    <span class="cmo-xml-tag">
+      <xsl:value-of select="name()" />
+    </span>
+    <xsl:call-template name="namespaces" />
+    <xsl:apply-templates select="@*" mode="xml" />
+    <xsl:choose>
+      <xsl:when test="not($hasContent)">
+        <span class="cmo-xml-punct">/&gt;</span>
+      </xsl:when>
+      <xsl:when test="$block">
+        <span class="cmo-xml-punct">&gt;</span>
+        <xsl:text>&#10;</xsl:text>
+        <xsl:apply-templates select="node()[not(self::text())]" mode="xml">
+          <xsl:with-param name="depth" select="$depth + 1" />
+        </xsl:apply-templates>
+        <xsl:value-of select="cmo:indent($depth)" />
+        <span class="cmo-xml-punct">&lt;/</span>
+        <span class="cmo-xml-tag">
+          <xsl:value-of select="name()" />
+        </span>
+        <span class="cmo-xml-punct">&gt;</span>
+      </xsl:when>
+      <xsl:otherwise>
+        <!-- inline content: keep text nodes and render child elements inline -->
+        <span class="cmo-xml-punct">&gt;</span>
+        <xsl:apply-templates select="node()" mode="xml">
+          <xsl:with-param name="inline" select="true()" />
+        </xsl:apply-templates>
+        <span class="cmo-xml-punct">&lt;/</span>
+        <span class="cmo-xml-tag">
+          <xsl:value-of select="name()" />
+        </span>
+        <span class="cmo-xml-punct">&gt;</span>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:if test="not($inline)">
+      <xsl:text>&#10;</xsl:text>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- namespace declarations, emitted only where they differ from the parent -->
+  <xsl:template name="namespaces">
+    <xsl:variable name="e" select="." />
+    <xsl:variable name="pe" select="../self::*" />
+    <xsl:for-each select="in-scope-prefixes($e)[. != 'xml']">
+      <xsl:sort select="." />
+      <xsl:variable name="pfx" select="string(.)" />
+      <xsl:variable name="uri" select="namespace-uri-for-prefix($pfx, $e)" />
+      <xsl:variable name="parentUri"
+                    select="if (exists($pe)) then namespace-uri-for-prefix($pfx, $pe) else ()" />
+      <xsl:if test="empty($pe) or not($uri = $parentUri)">
+        <xsl:text> </xsl:text>
+        <span class="cmo-xml-attr-name">
+          <xsl:value-of select="if ($pfx = '') then 'xmlns' else concat('xmlns:', $pfx)" />
+        </span>
+        <span class="cmo-xml-punct">=</span>
+        <span class="cmo-xml-attr-value">
+          <xsl:text>"</xsl:text>
+          <xsl:value-of select="$uri" />
+          <xsl:text>"</xsl:text>
+        </span>
+      </xsl:if>
+    </xsl:for-each>
+  </xsl:template>
+
+  <!-- ========================== attributes =========================== -->
+
+  <xsl:template match="@*" mode="xml">
+    <xsl:text> </xsl:text>
+    <span class="cmo-xml-attr-name">
+      <xsl:value-of select="name()" />
+    </span>
+    <span class="cmo-xml-punct">=</span>
+    <span class="cmo-xml-attr-value">
+      <xsl:text>"</xsl:text>
+      <xsl:value-of select="." />
+      <xsl:text>"</xsl:text>
+    </span>
+  </xsl:template>
+
+  <!-- ===================== text, comments, PIs ======================= -->
+
+  <xsl:template match="text()" mode="xml">
+    <span class="cmo-xml-text">
+      <xsl:value-of select="." />
+    </span>
+  </xsl:template>
+
+  <xsl:template match="comment()" mode="xml">
+    <xsl:param name="depth" as="xs:integer" select="0" />
+    <xsl:param name="inline" as="xs:boolean" select="false()" />
+    <xsl:if test="not($inline)">
+      <xsl:value-of select="cmo:indent($depth)" />
+    </xsl:if>
+    <span class="cmo-xml-comment">
+      <xsl:text>&lt;!--</xsl:text>
+      <xsl:value-of select="." />
+      <xsl:text>--&gt;</xsl:text>
+    </span>
+    <xsl:if test="not($inline)">
+      <xsl:text>&#10;</xsl:text>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="processing-instruction()" mode="xml">
+    <xsl:param name="depth" as="xs:integer" select="0" />
+    <xsl:param name="inline" as="xs:boolean" select="false()" />
+    <xsl:if test="not($inline)">
+      <xsl:value-of select="cmo:indent($depth)" />
+    </xsl:if>
+    <span class="cmo-xml-pi">
+      <xsl:text>&lt;?</xsl:text>
+      <xsl:value-of select="name()" />
+      <xsl:text> </xsl:text>
+      <xsl:value-of select="." />
+      <xsl:text>?&gt;</xsl:text>
+    </span>
+    <xsl:if test="not($inline)">
+      <xsl:text>&#10;</xsl:text>
+    </xsl:if>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/cmo-module/src/main/resources/xsl/layout/metadataLayout.xsl
+++ b/cmo-module/src/main/resources/xsl/layout/metadataLayout.xsl
@@ -420,16 +420,22 @@
         <div data-upload-object="{$objID}" data-upload-target="/">
           <xsl:choose>
             <xsl:when test="count(structure/derobjects/derobject)=0">
-              <xsl:attribute name="class">drop-to-object cmo-file-upload-box card</xsl:attribute>
+              <xsl:attribute name="class">drop-to-object cmo-file-upload-box cmo-file-upload-box--new card</xsl:attribute>
             </xsl:when>
             <xsl:otherwise>
-              <xsl:attribute name="class">drop-to-object-optional cmo-file-upload-box card</xsl:attribute>
+              <xsl:attribute name="class">drop-to-object-optional cmo-file-upload-box cmo-file-upload-box--new card</xsl:attribute>
               <xsl:attribute name="style">display:none;</xsl:attribute>
             </xsl:otherwise>
           </xsl:choose>
           <div class="card-body text-center">
-            <i class="fas fa-upload"></i>
-            <xsl:value-of disable-output-escaping="yes" select="concat(' ', i18n:translate('cmo.upload.drop.derivate'))"/>
+            <div class="cmo-file-upload-box__title">
+              <i class="fas fa-folder-plus"></i>
+              <xsl:value-of select="concat(' ', i18n:translate('cmo.upload.drop.title.new'))"/>
+            </div>
+            <div class="cmo-file-upload-box__hint">
+              <i class="fas fa-upload"></i>
+              <xsl:value-of disable-output-escaping="yes" select="concat(' ', i18n:translate('cmo.upload.drop.derivate'))"/>
+            </div>
           </div>
         </div>
     </xsl:if>
@@ -447,10 +453,16 @@
         </xsl:call-template>
       </xsl:if>
       <xsl:if test="acl:checkPermission(@xlink:href, 'writedb')">
-        <div data-upload-object="{@xlink:href}" data-upload-target="/" class="drop-to-derivate cmo-file-upload-box card">
+        <div data-upload-object="{@xlink:href}" data-upload-target="/" class="drop-to-derivate cmo-file-upload-box cmo-file-upload-box--existing card">
           <div class="card-body text-center">
-            <i class="fas fa-upload"></i>
-            <xsl:value-of disable-output-escaping="yes" select="concat(' ', i18n:translate('cmo.upload.drop.derivate'))"/>
+            <div class="cmo-file-upload-box__title">
+              <i class="fas fa-folder-open"></i>
+              <xsl:value-of select="concat(' ', i18n:translate('cmo.upload.drop.title.existing'))"/>
+            </div>
+            <div class="cmo-file-upload-box__hint">
+              <i class="fas fa-upload"></i>
+              <xsl:value-of disable-output-escaping="yes" select="concat(' ', i18n:translate('cmo.upload.drop.derivate'))"/>
+            </div>
           </div>
         </div>
       </xsl:if>

--- a/cmo-module/src/main/resources/xsl/layout/viewer.xsl
+++ b/cmo-module/src/main/resources/xsl/layout/viewer.xsl
@@ -13,22 +13,183 @@
   <xsl:param name="WebApplicationBaseURL" />
 
   <xsl:template match="structure" mode="showViewer">
-    <xsl:if test="derobjects/derobject">
+    <!-- only derivates that are readable and actually have a main file get a tab -->
+    <xsl:variable name="readableDerivates"
+      select="derobjects/derobject[key('rights', @xlink:href)/@read
+                                   and string(mcrxsl:getMainDocName(@xlink:href)) != '']" />
+    <xsl:if test="count($readableDerivates) &gt; 0">
       <div id="cmo-viewer">
-          <xsl:if test="count(derobjects/derobject[key('rights', @xlink:href)/@read]) > 0">
-            <div class="row cmo-preview">
-              <div class="col-md-12">
-                <h3 class="cmo-viewer">Vorschau</h3>
-                <!-- show one viewer for each derivate -->
-                <xsl:for-each select="derobjects/derobject[key('rights', @xlink:href)/@read]">
-                  <xsl:call-template name="createViewer" />
-                </xsl:for-each>
-              </div>
+        <div class="row cmo-preview">
+          <div class="col-md-12">
+            <!-- one tab per readable derivate; the tab title is the derivate_types label.
+                 xml/tei main files get an extra "<label> (XML)" tab with the raw source -->
+            <ul class="nav nav-tabs cmo-viewer-tabs" role="tablist">
+              <xsl:for-each select="$readableDerivates">
+                <xsl:variable name="tabId" select="concat('cmo-tab-', @xlink:href)" />
+                <xsl:variable name="ext"
+                  select="translate(FilenameUtils:getExtension(mcrxsl:getMainDocName(@xlink:href)),
+                                    'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')" />
+                <xsl:variable name="label">
+                  <xsl:call-template name="viewerTabLabel">
+                    <xsl:with-param name="categid"
+                      select="classification[@classid='derivate_types']/@categid" />
+                  </xsl:call-template>
+                </xsl:variable>
+                <li class="nav-item" role="presentation">
+                  <a class="nav-link" role="tab" data-toggle="tab" href="#{$tabId}"
+                     id="{$tabId}-label" aria-controls="{$tabId}">
+                    <xsl:if test="position() = 1">
+                      <xsl:attribute name="class">nav-link active</xsl:attribute>
+                      <xsl:attribute name="aria-selected">true</xsl:attribute>
+                    </xsl:if>
+                    <xsl:copy-of select="$label" />
+                  </a>
+                </li>
+                <xsl:if test="$ext = 'xml' or $ext = 'tei'">
+                  <xsl:variable name="xmlTabId" select="concat('cmo-tab-', @xlink:href, '-xml')" />
+                  <li class="nav-item" role="presentation">
+                    <a class="nav-link" role="tab" data-toggle="tab" href="#{$xmlTabId}"
+                       id="{$xmlTabId}-label" aria-controls="{$xmlTabId}">
+                      <xsl:copy-of select="$label" />
+                      <xsl:text> (XML)</xsl:text>
+                    </a>
+                  </li>
+                </xsl:if>
+              </xsl:for-each>
+            </ul>
+            <div class="tab-content cmo-viewer-tab-content">
+              <xsl:for-each select="$readableDerivates">
+                <xsl:variable name="tabId" select="concat('cmo-tab-', @xlink:href)" />
+                <xsl:variable name="ext"
+                  select="translate(FilenameUtils:getExtension(mcrxsl:getMainDocName(@xlink:href)),
+                                    'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')" />
+                <div class="tab-pane fade" id="{$tabId}" role="tabpanel"
+                     aria-labelledby="{$tabId}-label">
+                  <xsl:if test="position() = 1">
+                    <xsl:attribute name="class">tab-pane fade show active</xsl:attribute>
+                  </xsl:if>
+                  <xsl:call-template name="viewerTabPane" />
+                </div>
+                <xsl:if test="$ext = 'xml' or $ext = 'tei'">
+                  <xsl:variable name="xmlTabId" select="concat('cmo-tab-', @xlink:href, '-xml')" />
+                  <div class="tab-pane fade" id="{$xmlTabId}" role="tabpanel"
+                       aria-labelledby="{$xmlTabId}-label">
+                    <xsl:call-template name="viewerXmlPane" />
+                  </div>
+                </xsl:if>
+              </xsl:for-each>
             </div>
-          </xsl:if>
+          </div>
+        </div>
+        <xsl:call-template name="loadTeiScript" />
       </div>
     </xsl:if>
     <xsl:apply-imports />
+  </xsl:template>
+
+  <!-- resolves the tab title from the derivate_types classification label -->
+  <xsl:template name="viewerTabLabel">
+    <xsl:param name="categid" />
+    <xsl:choose>
+      <xsl:when test="string($categid) != ''">
+        <xsl:variable name="cat"
+          select="document(concat('classification:metadata:0:children:derivate_types:', $categid))//category[@ID=$categid]" />
+        <xsl:choose>
+          <xsl:when test="$cat/label[@xml:lang=$CurrentLang]">
+            <xsl:value-of select="$cat/label[@xml:lang=$CurrentLang]/@text" />
+          </xsl:when>
+          <xsl:when test="$cat/label[@xml:lang='en']">
+            <xsl:value-of select="$cat/label[@xml:lang='en']/@text" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$categid" />
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="i18n:translate('cmo.viewer.preview')" />
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!--
+    Renders the content of a single viewer tab. The rendering is chosen by the file
+    extension of the main file, not by the derivate type: an xml/tei main file is shown
+    as a TEI edition, everything else (pdf, images, ...) uses the mycore image viewer.
+    The derivate type is only used for the tab title.
+  -->
+  <xsl:template name="viewerTabPane">
+    <xsl:variable name="derId" select="@xlink:href" />
+    <xsl:variable name="mainFile" select="mcrxsl:getMainDocName($derId)" />
+    <xsl:variable name="ext"
+      select="translate(FilenameUtils:getExtension($mainFile),
+                        'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')" />
+    <xsl:choose>
+      <xsl:when test="$ext = 'xml' or $ext = 'tei'">
+        <xsl:variable name="teiSrc"
+          select="concat($ServletsBaseURL, 'MCRDerivateContentTransformerServlet/', $derId, '/',
+                         mcrxsl:encodeURIPath($mainFile), '?XSL.Style=cmoedition')" />
+        <!-- the actual TEI html is loaded lazily by loadTeiScript when the tab is shown -->
+        <div class="cmo-tei" data-tei-src="{$teiSrc}">
+          <div class="cmo-tei-loading text-muted">
+            <span class="fas fa-spinner fa-spin"></span>
+            <xsl:text> </xsl:text>
+            <xsl:value-of select="i18n:translate('cmo.viewer.tei.loading')" />
+          </div>
+        </div>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:call-template name="createViewer" />
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!--
+    Renders the "(XML)" tab: the raw main file is transformed to a pretty printed and
+    syntax highlighted html fragment (XSL.Style=cmosource) and loaded lazily, reusing
+    the same mechanism as the TEI edition tab (see loadTeiScript).
+  -->
+  <xsl:template name="viewerXmlPane">
+    <xsl:variable name="derId" select="@xlink:href" />
+    <xsl:variable name="mainFile" select="mcrxsl:getMainDocName($derId)" />
+    <xsl:variable name="xmlSrc"
+      select="concat($ServletsBaseURL, 'MCRDerivateContentTransformerServlet/', $derId, '/',
+                     mcrxsl:encodeURIPath($mainFile), '?XSL.Style=cmosource')" />
+    <div class="cmo-tei" data-tei-src="{$xmlSrc}">
+      <div class="cmo-tei-loading text-muted">
+        <span class="fas fa-spinner fa-spin"></span>
+        <xsl:text> </xsl:text>
+        <xsl:value-of select="i18n:translate('cmo.viewer.xml.loading')" />
+      </div>
+    </div>
+  </xsl:template>
+
+  <!-- lazily loads the TEI edition into its tab and relayouts image viewers on tab change -->
+  <xsl:template name="loadTeiScript">
+    <script type="text/javascript">
+      (function() {
+        function loadTei(el) {
+          if (el.getAttribute('data-loaded')) {
+            return;
+          }
+          el.setAttribute('data-loaded', '1');
+          $(el).load(el.getAttribute('data-tei-src'));
+        }
+        $(function() {
+          $('#cmo-viewer .tab-pane.active .cmo-tei[data-tei-src]').each(function() {
+            loadTei(this);
+          });
+          $('#cmo-viewer a[data-toggle="tab"]').on('shown.bs.tab', function(e) {
+            var pane = $($(e.target).attr('href'));
+            pane.find('.cmo-tei[data-tei-src]').each(function() {
+              loadTei(this);
+            });
+            // image viewers that were initialised while hidden need a relayout
+            $(window).trigger('resize');
+          });
+        });
+      })();
+    </script>
   </xsl:template>
 
   <xsl:template name="createViewer">


### PR DESCRIPTION
Closes #294

## What

The object viewer now shows one tab per readable derivate, with the tab title taken from the `derivate_types` classification label. What a tab renders is decided by the **main file extension**, not the derivate type (the type is only used for the title):

- **xml/tei** main files are rendered as a **TEI text edition** (new XSLT 3.0 stylesheet `TEI-cmoedition.xsl`, executed with Saxon, loaded lazily via `MCRDerivateContentTransformerServlet`) and additionally get a **`<label> (XML)`** tab showing the raw source, pretty printed and syntax highlighted (`TEI-cmosource.xsl`).
- **everything else** (pdf, images) uses the mycore image viewer as before.
- derivates without a main file no longer produce an empty tab.

The XML source view walks the tree and emits themed `<span>` classes for tags, attributes, values, text and comments (colours in `_tei.scss`); no external JS highlighter is needed. Mixed content is kept on one line so significant whitespace is preserved.

## Also included

Upload boxes: "add to an existing filespace" is now visually separated from "create a new filespace" so it is clear what an upload will do (`metadataLayout.xsl`, `_metadata.scss`, new i18n keys).

## Notes

- SCSS compiles at runtime (`MCR.SASS.DeveloperMode`), the cmo-module ships in the WAR.
- New transformers `TEI-cmoedition` / `TEI-cmosource` are configured in `mycore.properties` (Saxon, XSLT 3.0).
- `cmo-module` builds cleanly (`mvn -pl cmo-module install`, tests green).

## Test
- Verified `TEI-cmosource.xsl` against the real edition file of `cmo_mods_00000602` (Saxon-HE 9.8): well-formed output, balanced spans, namespaces and mixed content correct.